### PR TITLE
add flake8 configuration and GitHub Actions workflow -- updt one 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+max-line-length = 130
+extend-ignore = E203, W503
+exclude = 
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    build,
+    dist,
+    *.egg-info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Vérification PEP8 avec flake8
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Récupération du code
+      uses: actions/checkout@v4
+    
+    - name: Installation de Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    
+    - name: Installation de uv
+      uses: astral-sh/setup-uv@v3
+    
+    - name: Synchronisation des dépendances
+      run: uv sync
+    
+    - name: Vérification PEP8 avec flake8
+      run: uv run flake8 src/
+      

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ __pycache__/
 data/raw/
 data/
 
-#flake8
-.flake8
 
 # Build utilitaire
 Makefile


### PR DESCRIPTION
# Contexte 

Mise en place de Flake8 pour uniformiser la qualité du code (PEP8)
et ajout d’un workflow GitHub Actions pour exécuter automatiquement le lint à chaque push ou pull request.

# Changements 

Ajout du fichier .flake8
→ Configuration du linter avec une limite de 130 caractères par ligne (la valeur par défaut de Black est 88).

Ajout du workflow .github/workflows/lint.yml
→ Automatisation de la vérification PEP8 sur chaque push ou PR vers main.
Le job exécute flake8 dans un environnement Python 3.11 via uv, garantissant la cohérence entre la configuration locale et celle du pipeline CI.

Nettoyage du .gitignore
→ Retrait de la ligne qui excluait .flake8, afin d’appliquer la même limite de 130 caractères pour tout le monde, que ce soit en local ou dans la CI.